### PR TITLE
Support BCH addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ bin/SHA256SUMS.asc
 *.orig
 package-lock.json
 data/*
+.vscode/launch.json

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ bin/SHA256SUMS.asc
 *.bak
 *.orig
 package-lock.json
+data/*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Bitcore Node (BCH)
 ============
 
-
+## !! THIS IS STILL IN BETA, Please use with caution and check the open issues before using!!
 ## Prerequisites
 
 - Bitcoin Cash Full node (local/remote).
@@ -22,7 +22,7 @@ npm install
 
 ## Configuration
 
-Note: This Bitcore node will "attach" to a running full node (you need to set the ip of the full node, in the main configuration file is called `"bitcore-node.json`), so you need to have the Bitcoin Cash node running before starting this node. I would recommend using the same setting in `bitcoin.conf.sample` to setup the full Bitcoin-Cash node (at least the RPC settings since Bitcore uses the same RPC credentials by default.)
+This Bitcore node will "attach" to a running full node (you need to specify the ip of the full node in the main configuration file `"bitcore-node.json`), **you need to have the Bitcoin Cash node running before starting this node**. I would recommend using the same setting in `bitcoin.conf.sample` to setup the full Bitcoin-Cash node (at least the RPC settings since Bitcore uses the same RPC credentials by default.)
 
 The config file instructs bitcore-node for the following options:
 - location of database files (datadir)
@@ -30,6 +30,7 @@ The config file instructs bitcore-node for the following options:
 - bitcoin-cash network type (e.g. `mainnet`, `testnet`, `regtest`), (network)
 - what services to include (services)
 - the services' configuration (servicesConfig)
+- ip of the bitcoin cash peer, along with its RPC settings.
 
 ## Documentation
 

--- a/bitcore-node.json
+++ b/bitcore-node.json
@@ -31,7 +31,16 @@
     "p2p": {
       "peers": [
         { "ip": { "v4": "127.0.0.1" } }
-      ]
+      ],
+      "rpc":{
+          "host":"127.0.0.1",
+          "port":8332,
+          "pass":"local321",
+          "protocol":"http",
+          "user":"bitcoin"
+      }
+          
+      
     },
     "fee": {
       "rpc": {

--- a/lib/services/address/index.js
+++ b/lib/services/address/index.js
@@ -41,11 +41,8 @@ var AddressService = function(options) {
   });
  
 
-  if (this._network === 'livenet') {
+  if (this._network === 'livenet' || this._network === 'mainnet') {
     this._network = 'main';
-  }
-  if (this._network === 'regtest') {
-    this._network = 'testnet';
   }
 
 };
@@ -630,7 +627,7 @@ AddressService.prototype._removeInput = function(input, tx, block, index, callba
   }
 
   address.network = self._network;
-  address = address.toString();
+  address = address.toString(self._network);
 
   assert(block && block.__ts && block.__height, 'Missing block or block values.');
 
@@ -674,7 +671,7 @@ AddressService.prototype._removeOutput = function(output, tx, block, index, call
   }
 
   address.network = self._network;
-  address = address.toString();
+  address = address.toString(self._network);
 
   assert(block && block.__ts && block.__height, 'Missing block or block values.');
 
@@ -743,7 +740,7 @@ AddressService.prototype._processInput = function(tx, input, index, opts) {
   }
 
   address.network = this._network;
-  address = address.toString();
+  address = address.toString(this._network);
 
   var txid = tx.txid();
   var timestamp = this._timestamp.getTimestampSync(opts.block.rhash());
@@ -781,7 +778,7 @@ AddressService.prototype._processOutput = function(tx, output, index, opts) {
   }
 
   address.network = this._network;
-  address = address.toString();
+  address = address.toString(this._network);
 
   var txid = tx.txid();
   var timestamp = this._timestamp.getTimestampSync(opts.block.rhash());

--- a/lib/services/mempool/index.js
+++ b/lib/services/mempool/index.js
@@ -17,11 +17,8 @@ var MempoolService = function(options) {
   this._flush = options.flush;
   this._enabled = false;
 
-  if (this._network === 'livenet') {
+  if (this._network === 'livenet' || this._network === 'mainnet') {
     this._network = 'main';
-  }
-  if (this._network === 'regtest') {
-    this._network = 'testnet';
   }
 };
 

--- a/lib/services/transaction/index.js
+++ b/lib/services/transaction/index.js
@@ -18,11 +18,8 @@ function TransactionService(options) {
   this._timestamp = this.node.services.timestamp;
   this._network = this.node.network;
 
-  if (this._network === 'livenet') {
+  if (this._network === 'livenet' || this._network === 'mainnet') {
     this._network = 'main';
-  }
-  if (this._network === 'regtest') {
-    this._network = 'testnet';
   }
 
   // caches

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -175,7 +175,7 @@ utils.getAddress = function(item, network) {
     return;
   }
   address.network = network;
-  return address.toString();
+  return address.toString(network);
 };
 
 module.exports = utils;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "async": "^2.5.0",
-    "bcoin": "github:osagga/bcoin#bcash-address-fix",
+    "bcoin": "github:osagga/bcoin#fix-bch-addresses",
     "bitcoind-rpc": "^0.6.0",
     "bitcore-lib-cash": "osagga/bitcore-lib#fix-cash-address-parsing",
     "bitcore-p2p": "osagga/bitcore-p2p#master",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bitcore-cash",
+  "name": "bitcore-node-cash",
   "description": "Full node with extended capabilities to support Bitcoin cash using Bitcore",
   "engines": {
     "node": ">=8.2.0"

--- a/package.json
+++ b/package.json
@@ -1,16 +1,23 @@
 {
-  "name": "bitcore-node",
-  "description": "Full node with extended capabilities using Bitcore and Bitcoin Core",
+  "name": "bitcore-cash",
+  "description": "Full node with extended capabilities to support Bitcoin cash using Bitcore",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.2.0"
   },
   "author": "BitPay <dev@bitpay.com>",
-  "version": "5.0.0-beta.44",
+  "contributors": [
+    {
+      "name": "Omar Sagga",
+      "email": "osagga@outlook.com",
+      "url": "https://github.com/osagga"
+    }
+  ],
+  "version": "5.0.1-alpha",
   "main": "./index.js",
-  "repository": "git://github.com/bitpay/bitcore-node.git",
+  "repository": "git://github.com/osagga/bitcore-node.git",
   "homepage": "https://github.com/bitpay/bitcore-node",
   "bugs": {
-    "url": "https://github.com/bitpay/bitcore-node/issues"
+    "url": "https://github.com/osagga/bitcore-node/issues"
   },
   "bin": {
     "bitcore-node": "./bin/bitcore-node"
@@ -22,10 +29,12 @@
     "bitcoin",
     "bitcoind",
     "bcoin",
+    "bch",
+    "bch full node",
+    "bitcoin cash full node",
     "bitcoin full node",
     "bitcoin index",
-    "block explorer",
-    "wallet backend"
+    "block explorer"
   ],
   "dependencies": {
     "async": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -29,16 +29,18 @@
   ],
   "dependencies": {
     "async": "^2.5.0",
-    "bn.js": "^4.11.8",
-    "bitcore-lib-cash": "osagga/bitcore-lib#cash",
-    "bcoin": "bitpay/bcoin#v1.0.0-beta.14+cash",
+    "bcoin": "github:osagga/bcoin#bcash-address-fix",
     "bitcoind-rpc": "^0.6.0",
+    "bitcore-lib-cash": "osagga/bitcore-lib#fix-cash-address-parsing",
     "bitcore-p2p": "osagga/bitcore-p2p#master",
+    "bn.js": "^4.11.8",
     "body-parser": "^1.13.3",
     "colors": "^1.1.2",
     "commander": "^2.8.1",
     "errno": "^0.1.4",
     "express": "^4.13.3",
+    "insight-api": "osagga/insight-api#fixing-bch-address-format",
+    "insight-ui": "0.4.0",
     "leveldown": "^2.0.0",
     "levelup": "^2.0.0",
     "liftoff": "^2.2.0",
@@ -49,9 +51,7 @@
     "path-is-absolute": "^1.0.0",
     "socket.io": "^1.4.5",
     "socket.io-client": "^1.4.5",
-    "xxhash": "^0.2.4",
-    "insight-api": "osagga/insight-api#cash_v1",
-    "insight-ui": "0.4.0"
+    "xxhash": "^0.2.4"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Currently the `bitcore-node` only understands BTC legacy addresses, but with this PR, the API should only handle the BCH specific address format for all the different networks (`livenet`, `testnet` and `regtest`)

For example:
`livenet`(`mainnet`) address would be `bitcoincash:qzc85arqpfasynxearalwsnnlf4e37arggua57v7x5`
`testnet` address would be `bchtest:pp05efv92sk55jzq369v9zjss8trjn5lusxu6grry9`
`regtest` address would be `bchreg:qzc85arqpfasynxearalwsnnlf4e37arggua57v7x5`