### PR TITLE
Use original bitcore-lib-cash and minimal bcoin

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
   ],
   "dependencies": {
     "async": "^2.5.0",
-    "bcoin": "github:osagga/bcoin#fix-bch-addresses",
+    "bcoin": "github:osagga/bcoin#fix-address-minimal",
     "bitcoind-rpc": "^0.6.0",
-    "bitcore-lib-cash": "osagga/bitcore-lib#fix-cash-address-parsing",
+    "bitcore-lib-cash": "bitpay/bitcore-lib-cash",
     "bitcore-p2p": "osagga/bitcore-p2p#master",
     "bn.js": "^4.11.8",
     "body-parser": "^1.13.3",


### PR DESCRIPTION
I found a maintained [`bitcore-lib-cash`](https://github.com/bitpay/bitcore-lib-cash) library that seems to work with this node without any problems, so I'll start depending on that library instead of my own fork.

Also I'm now using a fork of `bcoin` that is minimally edited to resolve the problem with parsing BCH addresses. 